### PR TITLE
Add end-to-end test project for Chirp CLI

### DIFF
--- a/Chirp.CLI.sln
+++ b/Chirp.CLI.sln
@@ -11,6 +11,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chirp.CLI.Client.Test", "te
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chirp.SimpleDB.Test", "test\Chirp.SimpleDB.Test\Chirp.SimpleDB.Tests.csproj", "{526738D4-AEC8-4182-84AB-4E579B1EB8BC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chirp.EndToEnd.Tests", "test\Chirp.EndToEnd.Tests\Chirp.EndToEnd.Tests.csproj", "{80A92926-B1BB-4CAC-97B1-F82B2130C569}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{D9B6DE00-6FE1-45F4-AD7B-A9853905E44B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{526738D4-AEC8-4182-84AB-4E579B1EB8BC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{526738D4-AEC8-4182-84AB-4E579B1EB8BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80A92926-B1BB-4CAC-97B1-F82B2130C569}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80A92926-B1BB-4CAC-97B1-F82B2130C569}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80A92926-B1BB-4CAC-97B1-F82B2130C569}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80A92926-B1BB-4CAC-97B1-F82B2130C569}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/data/chirp_cli_db_test.csv
+++ b/data/chirp_cli_db_test.csv
@@ -1,0 +1,9 @@
+Author,Message,Timestamp
+ropf,"Hello, BDSA students!",1690891760
+adho,Welcome to the course!,1690978778
+adho,I hope you had a good summer.,1690979858
+ropf,Cheeping cheeps on Chirp :),1690981487
+TestName,Hello :D,12
+alexm,testetsetse,1757017282
+alexm,test.,1757017842
+hansv,lllkjklk,1757666451

--- a/test/Chirp.EndToEnd.Tests/Chirp.EndToEnd.Tests.csproj
+++ b/test/Chirp.EndToEnd.Tests/Chirp.EndToEnd.Tests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Chirp.EndToEnd.Test</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/test/Chirp.EndToEnd.Tests/End2End.cs
+++ b/test/Chirp.EndToEnd.Tests/End2End.cs
@@ -1,0 +1,75 @@
+﻿using System.Diagnostics;
+
+namespace Chirp.EndToEnd.Test;
+
+public class End2End
+{
+    [Fact]
+    public void TestReadCheep()
+    {
+        // Arrange
+        ArrangeTestDatabase();
+        string output = RunCli("read");
+
+        // Act
+        string fstCheep = output.Split("\n")[0].TrimEnd('\r', '\n');
+
+        // Assert
+        Assert.StartsWith("ropf", fstCheep);
+        Assert.EndsWith("Hello, BDSA students!", fstCheep);
+    }
+
+    [Fact]
+    public void TestStoreCheep()
+    {
+        // Arrange
+        ArrangeTestDatabase();
+        string testMessage = "This is a test cheep!";
+
+        // Act – store new cheep
+        RunCli($"cheep \"{testMessage}\"");
+
+        // Assert – read back and check the last line
+        string output = RunCli("read");
+        string lastCheep = output.Split("\n")
+                                 .Last(line => !string.IsNullOrWhiteSpace(line))
+                                 .TrimEnd('\r', '\n');
+
+        Assert.Contains(testMessage, lastCheep);
+        Assert.StartsWith(Environment.UserName, lastCheep);
+    }
+
+    private static string RunCli(string arguments)
+    {
+        var cliDll = Path.GetFullPath(
+            Path.Combine("..", "..", "..", "..", "..", "src", "Chirp.CLI.Client",
+                         "bin", "Debug", "net8.0", "Chirp.CLI.Client.dll")
+        );
+
+        using var process = new Process();
+        process.StartInfo.FileName = "dotnet";
+        process.StartInfo.Arguments = $"\"{cliDll}\" {arguments}";
+        process.StartInfo.UseShellExecute = false;
+        process.StartInfo.RedirectStandardOutput = true;
+        process.Start();
+
+        string output = process.StandardOutput.ReadToEnd();
+        process.WaitForExit();
+        return output;
+    }
+
+    private void ArrangeTestDatabase()
+    {
+        var exeDir = Path.GetFullPath(
+            Path.Combine("..", "..", "..", "..", "..", "src", "Chirp.CLI.Client",
+                         "bin", "Debug", "net8.0")
+        );
+        var dbPath = Path.Combine(exeDir, "chirp_cli_db.csv");
+
+        var templatePath = Path.GetFullPath(
+            Path.Combine("..", "..", "..", "..", "..", "data", "chirp_cli_db_test.csv")
+        );
+
+        File.Copy(templatePath, dbPath, overwrite: true);
+    }
+}


### PR DESCRIPTION
- Introduces the Chirp.EndToEnd.Tests project
- Initial tests for reading and storing cheeps. 
- Adds a test CSV database for consistent test data
- updates the solution file to include the new test project.

closes #25 