### PR TITLE
Read cheeps from CSV database in CheepService

### DIFF
--- a/src/Chirp.Razor/CheepService.cs
+++ b/src/Chirp.Razor/CheepService.cs
@@ -8,26 +8,22 @@ public interface ICheepService
 
 public class CheepService : ICheepService
 {
-    // These would normally be loaded from a database for example
-    private static readonly List<Cheep> _cheeps = new()
-    {
-        new Cheep("system", "No DB connected yet", DateTimeOffset.UtcNow.ToUnixTimeSeconds())
-    };
-
     public List<Cheep> GetCheeps()
     {
-        return _cheeps;
+        Console.WriteLine($"[CheepService] Reading cheeps from: {Path.GetFullPath("chirp_cli_db.csv")}");
+        return CsvDatabase<Cheep>.Instance.Read(100).ToList();
     }
 
     public List<Cheep> GetCheepsFromAuthor(string author)
     {
-        // filter by the provided author name
-        return _cheeps.Where(x => x.Author == author).ToList();
+        Console.WriteLine($"[CheepService] Reading cheeps for author {author} from: {Path.GetFullPath("chirp_cli_db.csv")}");
+        return CsvDatabase<Cheep>.Instance.Read()
+            .Where(x => x.Author == author)
+            .ToList();
     }
 
     public static string UnixTimeStampToDateTimeString(double unixTimeStamp)
     {
-        // Unix timestamp is seconds past epoch
         DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
         dateTime = dateTime.AddSeconds(unixTimeStamp);
         return dateTime.ToString("MM/dd/yy H:mm:ss");

--- a/src/Chirp.Razor/Chirp.Razor.csproj
+++ b/src/Chirp.Razor/Chirp.Razor.csproj
@@ -8,6 +8,10 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Chirp.SimpleDB\Chirp.SimpleDB.csproj" />
+      <Content Include="..\..\data\chirp_cli_db.csv">
+          <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+          <CopyToPublishDirectory>Always</CopyToPublishDirectory>
+      </Content>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
CheepService now reads cheeps from 'chirp_cli_db.csv' using CsvDatabase instead of a static list. The CSV file is included in the project output and publish directories for access at runtime.